### PR TITLE
Added dark mode styles and settings

### DIFF
--- a/src/tiny-suspender/css/popup-dark.css
+++ b/src/tiny-suspender/css/popup-dark.css
@@ -1,0 +1,57 @@
+body.dark-mode {
+  background-color: #333;
+}
+
+.dark-mode .buttons a {
+  color: #eee;
+}
+
+.dark-mode .buttons a:hover {
+  background-color: #555
+}
+
+.dark-mode #status_text {
+  background: #555;
+  color: #eee;
+}
+
+.dark-mode #status_text.blue {
+  background: #2196F3;
+}
+
+.dark-mode #status_text.yellow {
+  background: #ff9800;
+}
+
+.dark-mode #status_text.red {
+  background: #f44336;
+}
+
+.dark-mode #status_container {
+}
+
+.dark-mode form label {
+  color: #ccc;
+}
+
+.dark-mode form input[type=number] {
+  border-bottom: 1px solid #2196F3;
+  color: #ccc;
+}
+
+.dark-mode form input[type=number]:focus {
+  border-bottom: 2px solid #2196F3;
+}
+
+.dark-mode form small {
+  color: #ccc;
+}
+
+
+.dark-mode .section .bottom-status {
+  color: #ccc;
+}
+
+.dark-mode .section .bottom-status.red {
+  color: red;
+}

--- a/src/tiny-suspender/css/settings-dark.css
+++ b/src/tiny-suspender/css/settings-dark.css
@@ -1,0 +1,52 @@
+
+body.dark-mode {
+  color: #eee;
+  background-color: #333;
+}
+
+.dark-mode .header {
+  background: url(../img/icon-white-48.png) 10px 10px no-repeat;
+  background-color: #2196F3;
+  color: #eee;
+}
+
+
+
+.dark-mode .container {
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.24),
+              0 3px 1px -2px rgba(0,0,0,.29),
+              0 1px 5px 0 rgba(0,0,0,.17);
+  background: #333;
+  border: 1px solid hsl(207, 50%, 24%);
+}
+
+
+.dark-mode form a.shortcuts {
+  color: #2196f3;
+}
+
+.dark-mode form input[type=number] {
+  border-bottom: 1px solid #00BCD4;
+}
+
+.dark-mode form input[type=number]:focus {
+  border-bottom: 2px solid #00BCD4;
+}
+
+.dark-mode form textarea {
+  border-bottom: 1px solid #00BCD4;
+}
+
+.dark-mode form textarea:focus {
+  border-bottom: 2px solid #00BCD4;
+}
+
+.dark-mode form button {
+  background: #2196F3;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12);
+  color: #eee;
+}
+
+.dark-mode .infobox {
+  color: #aaa;
+}

--- a/src/tiny-suspender/css/suspend-dark.css
+++ b/src/tiny-suspender/css/suspend-dark.css
@@ -1,0 +1,24 @@
+body.dark-mode {
+    background-color: #333;
+}
+.dark-mode .title {
+  background-color: #333;
+  color: #eee;
+    border-bottom: 1px solid #555;
+}
+
+.dark-mode .title .icon {
+  background: none;
+}
+
+.dark-mode .title .description {
+  color: #eee;
+}
+
+.dark-mode .title .url {
+  color: #2196F3;
+}
+
+.dark-mode .suspend-message {
+  color: #eee;
+}

--- a/src/tiny-suspender/js/core.js
+++ b/src/tiny-suspender/js/core.js
@@ -17,6 +17,8 @@ class TinySuspenderCore {
     this.skipPinned= false;
     this.skipWhenOffline = false;
     this.enableTabDiscard = false;
+
+    this.darkMode = false;
   }
 
   log() {
@@ -93,13 +95,14 @@ class TinySuspenderCore {
         'skip_audible',
         'skip_pinned',
         'skip_when_offline',
-        'enable_tab_discard'
-        ], (items) => {
+        'enable_tab_discard',
+        'dark_mode'], (items) => {
         this.autorestore = items.autorestore;
         this.skipAudible = items.skip_audible;
         this.skipPinned = items.skip_pinned;
         this.skipWhenOffline = items.skip_when_offline;
         this.enableTabDiscard = items.enable_tab_discard;
+        this.darkMode = items.dark_mode;
 
         this.idleTimeMinutes = parseInt(items.idleTimeMinutes);
         if (isNaN(this.idleTimeMinutes)) {
@@ -126,7 +129,8 @@ class TinySuspenderCore {
           skipAudible: this.skip_audible,
           skipPinned: this.skip_pinned,
           skipWhenOffline: this.skipWhenOffline,
-          enableTabDiscard: this.enableTabDiscard
+          enableTabDiscard: this.enableTabDiscard,
+          darkMode: this.darkMode
         });
       });
     });
@@ -427,7 +431,14 @@ class TinySuspenderCore {
               this.log('this tab is already suspended via native tab discard: ', tab.id);
             }
             else {
-              this.chrome.tabs.update(tab.id, {url: 'suspend.html?url=' + encodeURIComponent(tab.url) + '&title=' + encodeURIComponent(tab.title) + '&favIconUrl=' + encodeURIComponent(tab.favIconUrl) + '&scroll_x=' + encodeURIComponent(scroll.x) + '&scroll_y=' + encodeURIComponent(scroll.y)});
+              this.chrome.tabs.update(tab.id, {
+                url: 'suspend.html?url=' + encodeURIComponent(tab.url)
+                   + '&title=' + encodeURIComponent(tab.title)
+                   + '&favIconUrl=' + encodeURIComponent(tab.favIconUrl)
+                   + '&scroll_x=' + encodeURIComponent(scroll.x)
+                   + '&scroll_y=' + encodeURIComponent(scroll.y)
+                   + '&dark_mode=' + encodeURIComponent(this.darkMode)
+              });
             }
           });
         }
@@ -468,7 +479,14 @@ class TinySuspenderCore {
               this.log('this tab is already suspended via native tab discard: ', tab.id);
             }
             else {
-              this.chrome.tabs.update(tab.id, {url: 'suspend.html?url=' + encodeURIComponent(tab.url) + '&title=' + encodeURIComponent(tab.title) + '&favIconUrl=' + encodeURIComponent(tab.favIconUrl) + '&scroll_x=' + encodeURIComponent(scroll.x) + '&scroll_y=' + encodeURIComponent(scroll.y)});
+              this.chrome.tabs.update(tab.id, {
+                url: 'suspend.html?url=' + encodeURIComponent(tab.url)
+                   + '&title=' + encodeURIComponent(tab.title)
+                   + '&favIconUrl=' + encodeURIComponent(tab.favIconUrl)
+                   + '&scroll_x=' + encodeURIComponent(scroll.x)
+                   + '&scroll_y=' + encodeURIComponent(scroll.y)
+                   + '&dark_mode=' + encodeURIComponent(this.darkMode)
+              });
             }
           });
         }

--- a/src/tiny-suspender/js/popup.js
+++ b/src/tiny-suspender/js/popup.js
@@ -34,7 +34,7 @@ class TinySuspenderPopup {
   }
 
   initQuickSettings() {
-    this.chrome.storage.sync.get(['idleTimeMinutes', 'enable_tab_discard'], (items) => {
+    this.chrome.storage.sync.get(['idleTimeMinutes', 'enable_tab_discard', 'dark_mode'], (items) => {
       this.idleTimeMinutes = parseInt(items.idleTimeMinutes);
       if (isNaN(this.idleTimeMinutes)) {
         this.idleTimeMinutes = 30;
@@ -51,6 +51,12 @@ class TinySuspenderPopup {
         tabDiscardElement.classList.add('red');
     
         document.querySelector('#bottom_status_container').appendChild(tabDiscardElement);
+      }
+
+      // enable dark mode
+      this.darkMode = items.dark_mode;
+      if(this.darkMode) {
+        document.body.classList.add('dark-mode');
       }
     });
   }

--- a/src/tiny-suspender/js/settings.js
+++ b/src/tiny-suspender/js/settings.js
@@ -7,7 +7,8 @@ let initSettings = () => {
     'skip_audible',
     'skip_pinned',
     'skip_when_offline',
-    'enable_tab_discard'], (items) => {
+    'enable_tab_discard',
+    'dark_mode'], (items) => {
     let idleTimeMinutes = parseInt(items.idleTimeMinutes);
     if (isNaN(idleTimeMinutes)) {
       idleTimeMinutes = 30;
@@ -55,6 +56,16 @@ let initSettings = () => {
     else {
       document.querySelector('#config input[name=enable_tab_discard]').removeAttribute('checked');
     }
+    if (items.dark_mode) {
+      document.querySelector('#config input[name=dark_mode]').setAttribute('checked', 'checked');
+      document.body.classList.add('dark-mode');
+    }
+    else {
+      document.querySelector('#config input[name=dark_mode]').removeAttribute('checked');
+      document.body.classList.remove('dark-mode');
+    }
+
+
   });
 }
 
@@ -75,6 +86,7 @@ let onSettingsSubmit = (e) => {
   let skip_pinned = document.querySelector('#config input[name=skip_pinned]').checked;
   let skip_when_offline = document.querySelector('#config input[name=skip_when_offline]').checked;
   let enable_tab_discard = document.querySelector('#config input[name=enable_tab_discard]').checked;
+  let dark_mode = document.querySelector('#config input[name=dark_mode]').checked;
 
   chrome.storage.sync.set({
     'idleTimeMinutes': idleTimeMinutes,
@@ -83,10 +95,15 @@ let onSettingsSubmit = (e) => {
     'skip_audible': skip_audible,
     'skip_when_offline': skip_when_offline,
     'skip_pinned': skip_pinned,
-    'enable_tab_discard': enable_tab_discard
+    'enable_tab_discard': enable_tab_discard,
+    'dark_mode': dark_mode
   }, () => {
     document.querySelector('#message').textContent = 'Setting saved!';
     document.querySelector('#message2').textContent = 'Setting saved!';
+
+    // check if dark mode is enabled
+    if(dark_mode) document.body.classList.add('dark-mode');
+    else document.body.classList.remove('dark-mode');
   });
 }
 

--- a/src/tiny-suspender/js/suspend.js
+++ b/src/tiny-suspender/js/suspend.js
@@ -3,6 +3,7 @@ let suspendUrl = new URL(location.href);
 let pageUrl = suspendUrl.searchParams.get('url');
 let favIconUrl = suspendUrl.searchParams.get('favIconUrl');
 let title = suspendUrl.searchParams.get('title');
+let darkMode = suspendUrl.searchParams.get('dark_mode') === 'true';
 
 // compatibility with previous version
 // will be removed in the next version
@@ -57,4 +58,8 @@ if (favIconUrl) {
 if (title) {
   document.title = title;
   document.querySelector('.title .description').textContent = title;
+}
+
+if (darkMode) {
+  document.body.classList.add('dark-mode');
 }

--- a/src/tiny-suspender/popup.html
+++ b/src/tiny-suspender/popup.html
@@ -4,6 +4,7 @@
   <title>Tiny Suspender</title>
   <!-- <link rel="stylesheet" type="text/css" href="css/material.css"> -->
   <link rel="stylesheet" type="text/css" href="css/popup.css">
+  <link rel="stylesheet" type="text/css" href="css/popup-dark.css">
 </head>
 <body>
 

--- a/src/tiny-suspender/settings.html
+++ b/src/tiny-suspender/settings.html
@@ -3,6 +3,7 @@
 <head>
   <title>Tiny Suspender: Settings</title>
   <link rel="stylesheet" type="text/css" href="css/settings.css">
+  <link rel="stylesheet" type="text/css" href="css/settings-dark.css">
 </head>
 <body>
   <div class="container">
@@ -31,7 +32,12 @@
         <label><input type="checkbox" name="skip_when_offline" value="enabled"> Don't automatically suspend tabs when offline</label>
       </div>
 
-      <div class="fieldset">
+      <div class="fieldset checkbox">
+        <label><input type="checkbox" name="dark_mode" value="disabled"> Toggle Dark Mode</label>
+      </div>
+
+
+        <div class="fieldset">
         <label>Whitelist:</label>
         <textarea name="whitelist" placeholder="/google/"></textarea>
         <small>

--- a/src/tiny-suspender/suspend.html
+++ b/src/tiny-suspender/suspend.html
@@ -3,6 +3,7 @@
 <head>
   <title>Suspended</title>
   <link rel="stylesheet" type="text/css" href="css/suspend.css">
+  <link rel="stylesheet" type="text/css" href="css/suspend-dark.css">
 </head>
 <body data-suspended="true">
   <div class="title">


### PR DESCRIPTION
I added an option to toggle night mode for the popup, settings and suspended page. 
However, the solution for the detection of dark mode preference on suspended page relies on parsing URL, so when dark mode is toggled off, the suspended status pages won't be updated if they're shown before the change. Not sure how to circumvent this, or if it matters at all.

_Edit_
**Screenshots:**  

+ [Settings page](https://i.imgur.com/VpB4YcP.png)
+ [Suspended page](https://i.imgur.com/LDOdDJN.png)
+ [Popup](https://i.imgur.com/TSETJB7.png)